### PR TITLE
Pamelas formatting and renaming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,20 @@ An Azure Storage Emulator is needed for this particular sample because we will s
 
 ## Run your MCP Server locally from the terminal
 
-1. Change to the src folder in a new terminal window
+1. Change to the src folder in a new terminal window:
+
    ```shell
    cd src
    ```
 
-1. Install Python dependencies
+1. Install Python dependencies:
+
    ```shell
    pip install -r requirements.txt
    ```
 
 1. Start the Functions host locally:
+
    ```shell
    func start
    ```
@@ -72,9 +75,11 @@ An Azure Storage Emulator is needed for this particular sample because we will s
 ### VS Code - Copilot Edits
 
 1. **Add MCP Server** from command palette and add URL to your running Function app's SSE endpoint:
+
     ```shell
     http://0.0.0.0:7071/runtime/webhooks/mcp/sse
     ```
+
 1. **List MCP Servers** from command palette and start the server
 1. In Copilot chat agent mode enter a prompt to trigger the tool, e.g., select some code and enter this prompt
 
@@ -89,6 +94,7 @@ An Azure Storage Emulator is needed for this particular sample because we will s
     ```plaintext
     Retrieve snippet1 and apply to newFile.py
     ```
+
 1. When prompted to run the tool, consent by clicking **Continue**
 
 1. When you're done, press Ctrl+C in the terminal window to stop the Functions host process.
@@ -102,11 +108,13 @@ An Azure Storage Emulator is needed for this particular sample because we will s
     ```
 
 2. CTRL click to load the MCP Inspector web app from the URL displayed by the app (e.g. http://0.0.0.0:5173/#resources)
-3. Set the transport type to `SSE` 
+3. Set the transport type to `SSE`
 4. Set the URL to your running Function app's SSE endpoint and **Connect**:
+
     ```shell
     http://0.0.0.0:7071/runtime/webhooks/mcp/sse
     ```
+
 5. **List Tools**.  Click on a tool and **Run Tool**.  
 
 ## Deploy to Azure for Remote MCP
@@ -123,11 +131,11 @@ You can opt-in to a VNet being used in the sample. To do so, do this before `azd
 azd env set VNET_ENABLED true
 ```
 
-Additionally, [API Management]() can be used for improved security and policies over your MCP Server, and [App Service built-in authentication](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization) can be used to set up your favorite OAuth provider including Entra.  
+Additionally, [API Management]() can be used for improved security and policies over your MCP Server, and [App Service built-in authentication](https://learn.microsoft.com/azure/app-service/overview-authentication-authorization) can be used to set up your favorite OAuth provider including Entra.  
 
 ### Connect to your function app from a client
 
-Your client will need a key in order to invoke the new hosted SSE endpoint, which will be of the form `https://<funcappname>.azurewebsites.net/runtime/webhooks/mcp/sse`. The hosted function requires a system key by default which can be obtained from the [portal](https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to?tabs=azure-portal) or the CLI (`az functionapp keys list --resource-group <resource_group> --name <function_app_name>`). Obtain the system key named `mcp_extension`.
+Your client will need a key in order to invoke the new hosted SSE endpoint, which will be of the form `https://<funcappname>.azurewebsites.net/runtime/webhooks/mcp/sse`. The hosted function requires a system key by default which can be obtained from the [portal](https://learn.microsoft.com/azure/azure-functions/function-keys-how-to?tabs=azure-portal) or the CLI (`az functionapp keys list --resource-group <resource_group> --name <function_app_name>`). Obtain the system key named `mcp_extension`.
 
 For MCP Inspector, you can include the key in the URL: `https://<funcappname>.azurewebsites.net/runtime/webhooks/mcp/sse?code=<your-mcp-extension-system-key>`.
 
@@ -284,6 +292,6 @@ Note that the `host.json` file also includes a reference to the experimental bun
 ## Next Steps
 
 - Add [API Management]() to your MCP server
-- Add [EasyAuth]() to your MCP server
+- Add [built-in auth]() to your MCP server
 - Enable VNET using VNET_ENABLED=true flag
 - Learn more about [related MCP efforts from Microsoft]()

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ urlFragment: remote-mcp-functions-python
 
 # Getting Started with Remote MCP Servers using Azure Functions (Python)
 
-This is a quickstart template to easily build and deploy a custom remote MCP server to the cloud using Azure Functions with Python. You can clone/restore/run on your local machine with debugging, and `azd up` to have it in the cloud in a couple minutes. The MCP server is secured by design using keys and HTTPS, and allows more options for OAuth using EasyAuth and/or API Management as well as network isolation using VNET.
+This is a quickstart template to easily build and deploy a custom remote MCP server to the cloud using Azure Functions with Python. You can clone/restore/run on your local machine with debugging, and `azd up` to have it in the cloud in a couple minutes. The MCP server is secured by design using keys and HTTPS, and allows more options for OAuth using built-in auth and/or API Management as well as network isolation using VNET.
 
 If you're looking for this sample in more languages check out the [.NET/C#](https://github.com/Azure-Samples/remote-mcp-functions-dotnet) and [Node.js/TypeScript](https://github.com/Azure-Samples/remote-mcp-functions-typescript) versions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+lint.select = ["E", "F", "I", "UP", "A"]
+lint.ignore = ["D203"]

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -1,13 +1,15 @@
-import azure.functions as func
-import logging
 import json
- 
+import logging
+
+import azure.functions as func
+
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
- 
+
 # Constants for the Azure Blob Storage container, file, and blob path
 _SNIPPET_NAME_PROPERTY_NAME = "snippetname"
 _SNIPPET_PROPERTY_NAME = "snippet"
 _BLOB_PATH = "snippets/{mcptoolargs." + _SNIPPET_NAME_PROPERTY_NAME + "}.json"
+
 
 class ToolProperty:
     def __init__(self, property_name: str, property_type: str, description: str):
@@ -19,27 +21,30 @@ class ToolProperty:
         return {
             "propertyName": self.propertyName,
             "propertyType": self.propertyType,
-            "description": self.description
+            "description": self.description,
         }
+
 
 # Define the tool properties using the ToolProperty class
 tool_properties_save_snippets_object = [
     ToolProperty(_SNIPPET_NAME_PROPERTY_NAME, "string", "The name of the snippet."),
-    ToolProperty(_SNIPPET_PROPERTY_NAME, "string", "The content of the snippet.")
+    ToolProperty(_SNIPPET_PROPERTY_NAME, "string", "The content of the snippet."),
 ]
 
-tool_properties_get_snippets_object = [
-    ToolProperty(_SNIPPET_NAME_PROPERTY_NAME, "string", "The name of the snippet.")
-]
+tool_properties_get_snippets_object = [ToolProperty(_SNIPPET_NAME_PROPERTY_NAME, "string", "The name of the snippet.")]
 
 # Convert the tool properties to JSON
 tool_properties_save_snippets_json = json.dumps([prop.to_dict() for prop in tool_properties_save_snippets_object])
 tool_properties_get_snippets_json = json.dumps([prop.to_dict() for prop in tool_properties_get_snippets_object])
 
 
-@app.generic_trigger(arg_name="context", type="mcpToolTrigger", toolName="hello", 
-                     description="Hello world.", 
-                     toolProperties="[]")
+@app.generic_trigger(
+    arg_name="context",
+    type="mcpToolTrigger",
+    toolName="hello_mcp",
+    description="Hello world.",
+    toolProperties="[]",
+)
 def hello_mcp(context) -> None:
     """
     A simple function that returns a greeting message.
@@ -56,24 +61,19 @@ def hello_mcp(context) -> None:
 @app.generic_trigger(
     arg_name="context",
     type="mcpToolTrigger",
-    toolName="getsnippet",
+    toolName="get_snippet",
     description="Retrieve a snippet by name.",
-    toolProperties=tool_properties_get_snippets_json
+    toolProperties=tool_properties_get_snippets_json,
 )
-@app.generic_input_binding(
-    arg_name="file",
-    type="blob",
-    connection="AzureWebJobsStorage",
-    path=_BLOB_PATH
-)
+@app.generic_input_binding(arg_name="file", type="blob", connection="AzureWebJobsStorage", path=_BLOB_PATH)
 def get_snippet(file: func.InputStream, context) -> str:
     """
     Retrieves a snippet by name from Azure Blob Storage.
- 
+
     Args:
         file (func.InputStream): The input binding to read the snippet from Azure Blob Storage.
         context: The trigger context containing the input arguments.
- 
+
     Returns:
         str: The content of the snippet or an error message.
     """
@@ -85,16 +85,11 @@ def get_snippet(file: func.InputStream, context) -> str:
 @app.generic_trigger(
     arg_name="context",
     type="mcpToolTrigger",
-    toolName="savesnippet",
+    toolName="save_snippet",
     description="Save a snippet with a name.",
-    toolProperties=tool_properties_save_snippets_json
-)                   
-@app.generic_output_binding(
-    arg_name="file",
-    type="blob",
-    connection="AzureWebJobsStorage",
-    path=_BLOB_PATH
+    toolProperties=tool_properties_save_snippets_json,
 )
+@app.generic_output_binding(arg_name="file", type="blob", connection="AzureWebJobsStorage", path=_BLOB_PATH)
 def save_snippet(file: func.Out[str], context) -> str:
     content = json.loads(context)
     snippet_name_from_args = content["arguments"][_SNIPPET_NAME_PROPERTY_NAME]
@@ -105,7 +100,7 @@ def save_snippet(file: func.Out[str], context) -> str:
 
     if not snippet_content_from_args:
         return "No snippet content provided"
- 
+
     file.set(snippet_content_from_args)
     logging.info(f"Saved snippet: {snippet_content_from_args}")
     return f"Snippet '{snippet_content_from_args}' saved successfully"


### PR DESCRIPTION
I ran ruff format and markdown lint, and also renamed the tools to be snake case / match their local definitions. The ruff settings can be configured in pyproject.toml if you don't like them, but they are what we use in many projects.