### PR TITLE
Update allowed locations to include 'japaneast' for resource deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,7 +7,7 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
-@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap', 'japaneast'])
 @metadata({
   azd: {
     type: 'location'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add 'japaneast' to the allowed regions in `main.bicep`.
* This change enables deployment to the Japan East region, as Azure Functions Flex Consumption is now supported there.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
[ ] Yes  
[x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
[ ] Bugfix  
[x] Feature  
[ ] Code style update (formatting, local variables)  
[ ] Refactoring (no functional changes, no api changes)  
[ ] Documentation content changes  
[ ] Other... Please describe:

## How to Test

* Test the code

```
azd up
```

## What to Check
Verify that the following are valid
* `japaneast` appears in the list of allowed regions during deployment.
* Resources are deployed successfully in the Japan East region.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* This update follows the recent support of Azure Functions Flex Consumption in the Japan East region.
