### PR TITLE
Update extension bundle ID in host.json

### DIFF
--- a/src/host.json
+++ b/src/host.json
@@ -9,7 +9,7 @@
     }
   },
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
This pull request updates the extension bundle configuration in `src/host.json` to use the stable Azure Functions Extension Bundle instead of the experimental version.

* Configuration update:
  * Changed the `extensionBundle.id` from `"Microsoft.Azure.Functions.ExtensionBundle.Experimental"` to `"Microsoft.Azure.Functions.ExtensionBundle"` in `src/host.json`, ensuring the project uses the stable extension bundle.