### PR TITLE
Fix VS Code F5 startup and add Bicep resource group output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,10 @@
 {
-    "azureFunctions.deploySubpath": "src",
+    "azureFunctions.deploySubpath": "src/McpWeatherApp",
     "azureFunctions.scmDoBuildDuringDeployment": true,
     "azureFunctions.pythonVenv": ".venv",
     "azureFunctions.projectLanguage": "Python",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
-    "azureFunctions.projectLanguageModel": 2
+    "azureFunctions.projectLanguageModel": 2,
+    "azureFunctions.defaultFunctionAppPath": "src/McpWeatherApp"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,23 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "create venv",
+			"type": "shell",
+			"osx": {
+				"command": "python3 -m venv ${config:azureFunctions.pythonVenv}"
+			},
+			"windows": {
+				"command": "python -m venv ${config:azureFunctions.pythonVenv}"
+			},
+			"linux": {
+				"command": "python3 -m venv ${config:azureFunctions.pythonVenv}"
+			},
+			"options": {
+				"cwd": "${workspaceFolder}/src/McpWeatherApp"
+			},
+			"problemMatcher": []
+		},
+		{
 			"label": "pip install (functions)",
 			"type": "shell",
 			"osx": {
@@ -16,7 +33,8 @@
 			"options": {
 				"cwd": "${workspaceFolder}/src/McpWeatherApp"
 			},
-			"problemMatcher": []
+			"problemMatcher": [],
+			"dependsOn": "create venv"
 		},
 		{
 			"type": "func",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
 				"command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
 			},
 			"options": {
-				"cwd": "${workspaceFolder}/src"
+				"cwd": "${workspaceFolder}/src/McpWeatherApp"
 			},
 			"problemMatcher": []
 		},
@@ -25,7 +25,7 @@
 			"problemMatcher": "$func-python-watch",
 			"isBackground": true,
 			"options": {
-				"cwd": "${workspaceFolder}/src"
+				"cwd": "${workspaceFolder}/src/McpWeatherApp"
 			},
 			"dependsOn": "func: extensions install"
 		},
@@ -34,7 +34,7 @@
 			"command": "extensions install",
 			"dependsOn": "pip install (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/src"
+				"cwd": "${workspaceFolder}/src/McpWeatherApp"
 			},
 			"problemMatcher": []
 		}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -263,6 +263,7 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
 // App outputs
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = rg.name
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
 output SERVICE_API_DEFAULT_HOSTNAME string = api.outputs.SERVICE_MCP_DEFAULT_HOSTNAME


### PR DESCRIPTION
- Adds `AZURE_RESOURCE_GROUP` Bicep output for post-provision hooks
- Fixes `.vscode/settings.json`: updates `deploySubpath` and adds `defaultFunctionAppPath` to `src/McpWeatherApp`
- Fixes `.vscode/tasks.json`: updates all task `cwd` paths to `src/McpWeatherApp`