### PR TITLE
Reorganize READMEs to match .NET repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,162 +16,43 @@ urlFragment: remote-mcp-functions-python
 
 # Getting Started with Remote MCP Servers using Azure Functions (Python)
 
-This is a quickstart template to easily build and deploy custom remote MCP servers to the cloud using Azure Functions with Python. You can clone/restore/run on your local machine with debugging, and `azd up` to have it in the cloud in a couple minutes. 
+This repo has a collection of samples to help you easily build and deploy a custom remote MCP server to the cloud using Azure Functions. You can clone/restore/run on your local machine with debugging, and `azd up` to have a server in the cloud in a couple minutes.
 
-The MCP servers are configured with [built-in authentication](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization) using Microsoft Entra as the identity provider.
+All sample MCP servers are configured with [built-in authentication](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization) using Microsoft Entra as the identity provider.
 
 You can also use [API Management](https://learn.microsoft.com/azure/api-management/secure-mcp-servers) to secure the server, as well as network isolation using VNET.
 
-If you're looking for this sample in more languages check out the [.NET/C#](https://github.com/Azure-Samples/remote-mcp-functions-dotnet) and [Node.js/TypeScript](https://github.com/Azure-Samples/remote-mcp-functions-typescript) versions.
+If you're looking for samples in more languages check out the [.NET/C#](https://github.com/Azure-Samples/remote-mcp-functions-dotnet) and [Node.js/TypeScript](https://github.com/Azure-Samples/remote-mcp-functions-typescript) versions.
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Azure-Samples/remote-mcp-functions-python)
-
-Below is the architecture diagram for the Remote MCP Server using Azure Functions:
-
-![Architecture Diagram](/media/architecture-diagram-http.png)
-
-## Sample Applications
-
-This repository includes two sample MCP applications:
-
-- **[FunctionsMcpTool](src/FunctionsMcpTool/README.md)** - An MCP server with sample tools demonstrating various patterns (hello world, snippet management, and more)
-- **[McpWeatherApp](src/McpWeatherApp/README.md)** - An interactive MCP App that displays weather information with a visual UI
-
-See each app's README for detailed setup and usage instructions.
 
 ## Prerequisites
 
 + [Python](https://www.python.org/downloads/) version 3.13 or higher
 + [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?pivots=programming-language-python#install-the-azure-functions-core-tools) >= `4.8.0`
-+ [Azure Developer CLI](https://aka.ms/azd)
-+ To use Visual Studio Code to run and debug locally:
-  + [Visual Studio Code](https://code.visualstudio.com/)
-  + [Azure Functions extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
++ [Azure Developer CLI](https://aka.ms/azd) **1.23.x or above** (for deployment)
++ [Docker](https://www.docker.com/) (for the Azurite storage emulator)
++ [Visual Studio Code](https://code.visualstudio.com/) (recommended)
++ [Azure Functions extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
 
-## Local testing
+Below is the architecture diagram for the Remote MCP Server using Azure Functions:
 
-Choose the sample app you want to run and follow its README:
+![Architecture Diagram](/media/architecture-diagram-http.png)
 
-- **[FunctionsMcpTool](src/FunctionsMcpTool/README.md)** - Sample tools (hello world, snippets, and more)
-- **[McpWeatherApp](src/McpWeatherApp/README.md)** - Interactive weather UI
+## Samples in this repo
 
-Each app's README contains detailed instructions for:
-- Setting up the local environment
-- Installing dependencies
-- Running the function app locally
-- Connecting from MCP clients (VS Code, MCP Inspector)
-- Testing and verification
+Each project README has instructions for running locally, connecting to the MCP server, deploying to the cloud, and more.
 
-## Deploy to Azure for Remote MCP
-
-### Step 1: Choose which app to deploy
-
-This repository contains multiple sample apps. Open [azure.yaml](azure.yaml) and set `project:` to the app you want to deploy:
-
-| App | `project:` value |
-|-----|-----------------|
-| FunctionsMcpTool (default) | `./src/FunctionsMcpTool` |
-| McpWeatherApp | `./src/McpWeatherApp` |
-
-```yaml
-services:
-  api:
-    project: ./src/FunctionsMcpTool    # ← change this to deploy a different app
-    language: python
-    host: function
-```
-
-### Step 2: Create an environment and configure
-
-In the root directory, create a new [azd](https://aka.ms/azd) environment:
-
-```shell
-azd env new <environment-name>
-```
-
-Configure VS Code as an allowed client application to request access tokens from Microsoft Entra:
-
-```shell
-azd env set PRE_AUTHORIZED_CLIENT_IDS aebc6443-996d-45c2-90f0-388ff96faa56
-```
-
-Optional: Enable VNet isolation:
-
-```bash
-azd env set VNET_ENABLED true
-```
-
-### Step 3: Deploy
-
-Run this azd command to provision the function app, with any required Azure resources, and deploy your code:
-
-```shell
-azd up
-```
-
-Additionally, [API Management](https://aka.ms/mcp-remote-apim-auth) can be used for improved security and policies over your MCP Server.
-
-### Step 4: Connect to remote MCP server in VS Code
-
-After deployment, connect to your remote MCP server using `https://<funcappname>.azurewebsites.net/runtime/webhooks/mcp`. 
-
-The [.vscode/mcp.json](.vscode/mcp.json) file is already configured with both local and remote server options. Click **Start** on the `remote-mcp-function` server and provide your function app name when prompted. The server uses built-in MCP authentication, so you'll be asked to login.
-
-## Redeploy your code
-
-You can run the `azd deploy` command as many times as you need to both provision your Azure resources and deploy code updates to your function app.
-
->[!NOTE]
->Deployed code files are always overwritten by the latest deployment package.
-
-## Clean up resources
-
-When you're done working with your function app and related resources, you can use this command to delete the function app and its related resources from Azure and avoid incurring any further costs:
-
-```shell
-azd down
-```
-
-## Troubleshooting
-
-| Error | Solution |
-|---|---|
-| `deployment was partially successful` / `KuduSpecializer` restart during `azd up` | This is a transient error. Run `azd deploy` to retry just the deployment step. |
-| `AttributeError: 'FunctionApp' object has no attribute 'mcp_resource_trigger'` | Python 3.13 is required. Verify with `python3 --version`. Install via `brew install python@3.13` (macOS) or from [python.org](https://www.python.org/downloads/). Recreate your virtual environment with Python 3.13 after installing. |
-
-## Helpful Azure Commands
-
-Once your application is deployed, you can use these commands to manage and monitor your application:
-
-```bash
-# Get your function app name from the environment file
-FUNCTION_APP_NAME=$(cat .azure/$(cat .azure/config.json | jq -r '.defaultEnvironment')/env.json | jq -r '.FUNCTION_APP_NAME')
-echo $FUNCTION_APP_NAME
-
-# Get resource group 
-RESOURCE_GROUP=$(cat .azure/$(cat .azure/config.json | jq -r '.defaultEnvironment')/env.json | jq -r '.AZURE_RESOURCE_GROUP')
-echo $RESOURCE_GROUP
-
-# View function app logs
-az webapp log tail --name $FUNCTION_APP_NAME --resource-group $RESOURCE_GROUP
-```
-
-## Architecture
-
-This sample demonstrates building MCP servers with Azure Functions using Python. It showcases two different patterns:
-
-1. **Simple MCP Tools** - Functions that expose tools using the `@app.mcp_tool()` decorator with Azure bindings (see [FunctionsMcpTool](src/FunctionsMcpTool/README.md))
-2. **MCP Apps** - Tools that return interactive UIs using MCP resources and the `ui://` scheme (see [McpWeatherApp](src/McpWeatherApp/README.md))
-
-Both patterns use the first-class MCP decorators available in `azure-functions>=2.0.0`, which:
-- Infer tool properties from function signatures and type hints
-- Eliminate manual JSON serialization
-- Integrate seamlessly with Azure Functions bindings
+| Project | Description | Getting Started |
+|---------|-------------|-----------------|
+| **FunctionsMcpTool** | MCP Tools — snippet CRUD, QR code generation, structured metadata, batch operations | [README](src/FunctionsMcpTool/README.md) |
+| **FunctionsMcpResources** | MCP Resources — snippet resource template, server info resource | [README](src/FunctionsMcpResources/README.md) |
+| **FunctionsMcpPrompts** | MCP Prompts — code review checklist, summarize content, generate docs | [README](src/FunctionsMcpPrompts/README.md) |
+| **McpWeatherApp** | Weather App — MCP App demo with interactive UI | [README](src/McpWeatherApp/README.md) |
 
 ## Next Steps
 
-- Learn more about the [Azure Functions MCP extension](https://learn.microsoft.com/azure/azure-functions/functions-bindings-mcp?pivots=programming-language-typescript)
-- Add [API Management](https://aka.ms/mcp-remote-apim-auth) to your MCP server (auth, gateway, policies, more!)
-- Enable VNET using VNET_ENABLED=true flag
-
++ Learn more about the [Azure Functions MCP extension](https://learn.microsoft.com/azure/azure-functions/functions-bindings-mcp?pivots=programming-language-typescript)
++ Learn more about [built-in MCP auth](https://learn.microsoft.com/azure/azure-functions/functions-mcp-tutorial?tabs=mcp-extension&pivots=programming-language-python#remote-mcp-server-authorization)
++ Follow our blog posts on [Azure SDK Blog](https://devblogs.microsoft.com/azure-sdk) and [Tech Community](https://techcommunity.microsoft.com/category/azure/blog/appsonazureblog) for updates.
 

--- a/src/FunctionsMcpPrompts/README.md
+++ b/src/FunctionsMcpPrompts/README.md
@@ -89,11 +89,51 @@ For remote servers, replace the server name accordingly (e.g., `/mcp.remote-mcp-
 
 ## Deploy to Azure
 
+### Step 1: Sign in
+
 ```shell
-azd env set DEPLOY_SERVICE prompts
-azd provision
-azd deploy --service prompts
+az login
+azd auth login
 ```
+
+### Step 2: Create an environment
+
+```shell
+azd env new <environment-name>
+```
+
+This also becomes the resource group name.
+
+### Step 3: Provision and deploy
+
+By default, OAuth-based authentication is enabled using the [built-in MCP auth feature](https://learn.microsoft.com/azure/app-service/configure-authentication-mcp?toc=/azure/azure-functions/toc.json&bc=/azure/azure-functions/breadcrumb/toc.json) with Microsoft Entra as the identity provider.
+
+Configure VS Code as an allowed client application for Microsoft Entra:
+
+```shell
+azd env set PRE_AUTHORIZED_CLIENT_IDS aebc6443-996d-45c2-90f0-388ff96faa56
+```
+
+Optionally enable VNet isolation:
+
+```shell
+azd env set VNET_ENABLED true
+```
+
+Deploy the project. When prompted, pick your subscription and an Azure region.
+
+```shell
+azd up
+```
+
+### Step 4: Connect to the remote MCP server
+
+Open **`.vscode/mcp.json`** and click **Start** above **`remote-mcp-function`**. You'll be prompted for `functionapp-name` — find it in your `azd` command output or the `.azure/<env>/.env` file. Since authentication is enabled, you'll also be prompted to sign in with Microsoft.
+
+### Redeploy and clean up
+
+- **Redeploy:** `azd deploy`
+- **Clean up all resources:** `azd down`
 
 ## Examining the code
 

--- a/src/FunctionsMcpResources/README.md
+++ b/src/FunctionsMcpResources/README.md
@@ -2,7 +2,7 @@
 
 This project is a Python Azure Function app that exposes MCP (Model Context Protocol) resource templates as a remote MCP server. Resource templates allow MCP clients to discover and read structured data through URI-based patterns.
 
-> **Note:** MCP tools are in the [FunctionsMcpTool](../FunctionsMcpTool) project, and prompts are in the [FunctionsMcpPrompts](../FunctionsMcpPrompts) project.
+> **Note:** MCP tools are in the [FunctionsMcpTool](../FunctionsMcpTool/) project, and prompts are in the [FunctionsMcpPrompts](../FunctionsMcpPrompts/) project.
 
 ## Resources included
 
@@ -17,46 +17,52 @@ This project is a Python Azure Function app that exposes MCP (Model Context Prot
 - **Static resources** have fixed URIs and return the same structure every call.
 - **Resource metadata** (like cache TTL) can be passed in the `metadata` parameter of the `@app.mcp_resource_trigger` decorator.
 
-## Prerequisites
-
-- [Python 3.13+](https://www.python.org/downloads/)
-- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?pivots=programming-language-python#install-the-azure-functions-core-tools) >= `4.5.0`
-- [Docker](https://www.docker.com/) (for the Azurite storage emulator — needed by the snippet resource template)
-
 > [!NOTE]
 > This project uses the **preview extension bundle** (`Microsoft.Azure.Functions.ExtensionBundle.Preview`) configured in `host.json`. The preview bundle is required because resource templates with URI parameters (e.g., `snippet://{Name}`) are not yet supported in the standard bundle.
 
-## Run locally
+## Prerequisites
 
-### 1. Start Azurite (required for the snippet resource which uses blob storage)
+- [Python 3.13+](https://www.python.org/downloads/)
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?pivots=programming-language-python#install-the-azure-functions-core-tools) >= `4.8.0`
+- [Azure Developer CLI (azd)](https://aka.ms/azd) **1.23.x or above** (for deployment)
+- [Docker](https://www.docker.com/) (for the Azurite storage emulator — needed by the snippet resource template)
 
-```bash
+## Prepare your local environment
+
+An Azure Storage Emulator is needed because the snippet resource reads blobs from storage. Start Azurite:
+
+```shell
 docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 \
-  mcr.microsoft.com/azure-storage/azurite \
-  azurite --skipApiVersionCheck --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0
+    mcr.microsoft.com/azure-storage/azurite \
+    azurite --skipApiVersionCheck --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0
 ```
 
-### 2. Install dependencies
+> If you use the Azurite VS Code extension instead, run **Azurite: Start** now.
+
+## Run locally
+
+### 1. Install dependencies
 
 Create and activate a virtual environment, then install dependencies:
 
-```bash
+```shell
 python3 -m venv .venv
-source .venv/bin/activate
+source .venv/bin/activate    # macOS/Linux
+.venv\Scripts\activate       # Windows
 pip install -r requirements.txt
 ```
 
-### 3. Start the Functions host
+### 2. Start the Functions host
 
 From this directory (`src/FunctionsMcpResources`), start the Functions host:
 
-```bash
+```shell
 func start
 ```
 
 The MCP endpoint will be available at `http://localhost:7071/runtime/webhooks/mcp`.
 
-### 4. Seed a snippet using the `save_snippet` tool
+### 3. Seed a snippet using the `save_snippet` tool
 
 This project includes a `save_snippet` MCP tool that writes snippets to blob storage. Use it to seed data before reading resources. For example, from VS Code Chat or MCP Inspector:
 
@@ -64,9 +70,15 @@ This project includes a `save_snippet` MCP tool that writes snippets to blob sto
 
 This creates a blob at `snippets/HelloWorld.json` which can then be read via the `snippet://HelloWorld` resource.
 
-## Connect from VS Code
+## Connect to the MCP server
 
-The [.vscode/mcp.json](../../.vscode/mcp.json) in the workspace root is already configured with a local server entry pointing to `http://localhost:7071/runtime/webhooks/mcp`. Click **Start** above the `local-mcp-function` server name.
+### Option A: VS Code with GitHub Copilot
+
+Open **`.vscode/mcp.json`** in the workspace root. Find the server called **`local-mcp-function`** and click **Start**. It points to:
+
+```
+http://localhost:7071/runtime/webhooks/mcp
+```
 
 MCP resources are attached as context in VS Code Chat (they aren't invoked like tools or prompts):
 
@@ -78,15 +90,68 @@ MCP resources are attached as context in VS Code Chat (they aren't invoked like 
    - **`Snippet`** — enter a snippet name (e.g., `HelloWorld`). Reads the matching blob from storage.
 5. The resource content is attached to the conversation as context for the model.
 
+### Option B: MCP Inspector
+
+1. Install and run MCP Inspector:
+
+   ```shell
+   npx @modelcontextprotocol/inspector
+   ```
+
+2. Open the Inspector URL (e.g. `http://0.0.0.0:5173/#resources`).
+3. Set the transport type to **Streamable HTTP**.
+4. Set the URL to `http://0.0.0.0:7071/runtime/webhooks/mcp` and click **Connect**.
+5. Click **List Resources** or **List Resource Templates** to browse available resources.
+
 ## Deploy to Azure
 
-From the repository root, use `azd` to deploy:
+### Step 1: Sign in
 
-```bash
-azd env set DEPLOY_SERVICE resources
-azd provision
-azd deploy --service resources
+```shell
+az login
+azd auth login
 ```
+
+### Step 2: Create an environment
+
+```shell
+azd env new <environment-name>
+```
+
+This also becomes the resource group name.
+
+### Step 3: Provision and deploy
+
+By default, OAuth-based authentication is enabled using the [built-in MCP auth feature](https://learn.microsoft.com/azure/app-service/configure-authentication-mcp?toc=/azure/azure-functions/toc.json&bc=/azure/azure-functions/breadcrumb/toc.json) with Microsoft Entra as the identity provider.
+
+Configure VS Code as an allowed client application for Microsoft Entra:
+
+```shell
+azd env set PRE_AUTHORIZED_CLIENT_IDS aebc6443-996d-45c2-90f0-388ff96faa56
+```
+
+Optionally enable VNet isolation:
+
+```shell
+azd env set VNET_ENABLED true
+```
+
+Deploy the project. When prompted, pick your subscription and an Azure region.
+
+```shell
+azd up
+```
+
+### Step 4: Connect to the remote MCP server
+
+Open **`.vscode/mcp.json`** and click **Start** above **`remote-mcp-function`**. You'll be prompted for `functionapp-name` — find it in your `azd` command output or the `.azure/<env>/.env` file. Since authentication is enabled, you'll also be prompted to sign in with Microsoft.
+
+> **Tip:** Click **More... → Show Output** above the server name to see request/response details.
+
+### Redeploy and clean up
+
+- **Redeploy:** `azd deploy`
+- **Clean up all resources:** `azd down`
 
 ## Examining the code
 
@@ -108,8 +173,6 @@ Resources are defined in [function_app.py](function_app.py). Each resource is a 
     connection="AzureWebJobsStorage"
 )
 def get_snippet_resource(context, snippet_content: Optional[bytes]) -> str:
-    # The {mcpresourceargs.Name} binding expression automatically extracts
-    # the Name parameter from the resource URI and passes it to the blob binding
     if snippet_content is None:
         return json.dumps({"error": "Snippet not found"})
     return snippet_content.decode('utf-8')
@@ -138,105 +201,11 @@ def get_server_info(context) -> str:
     return json.dumps(server_info)
 ```
 
-## Testing the resources
+## Troubleshooting
 
-### Using MCP Inspector
-
-Install and use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) to test your resources:
-
-```bash
-npx @modelcontextprotocol/inspector http://localhost:7071/runtime/webhooks/mcp
-```
-
-### Using curl
-
-Test the ServerInfo static resource:
-
-```bash
-curl -X POST http://localhost:7071/runtime/webhooks/mcp \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "resources/read",
-    "params": {
-      "uri": "info://server"
-    }
-  }'
-```
-
-List available resource templates:
-
-```bash
-curl -X POST http://localhost:7071/runtime/webhooks/mcp \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "resources/templates/list"
-  }'
-```
-
-Read a specific snippet:
-
-```bash
-curl -X POST http://localhost:7071/runtime/webhooks/mcp \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "resources/read",
-    "params": {
-      "uri": "snippet://HelloWorld"
-    }
-  }'
-```
-
-## Architecture
-
-```
-┌─────────────────┐
-│   MCP Client    │
-│  (e.g., Agent)  │
-└────────┬────────┘
-         │
-         │ HTTP
-         │
-┌────────▼────────────────────────┐
-│   Azure Functions (Python)      │
-│  ┌──────────────────────────┐   │
-│  │  get_snippet_resource    │   │
-│  │  (Resource Template)     │   │
-│  └──────────┬───────────────┘   │
-│             │                   │
-│             │ Blob Binding      │
-│             │                   │
-│  ┌──────────▼───────────────┐   │
-│  │   Azure Blob Storage     │   │
-│  │   (snippets container)   │   │
-│  └──────────────────────────┘   │
-│                                 │
-│  ┌──────────────────────────┐   │
-│  │   get_server_info        │   │
-│  │   (Static Resource)      │   │
-│  └──────────────────────────┘   │
-└─────────────────────────────────┘
-```
-
-## Sample snippets
-
-You can seed any JSON snippet into blob storage. The snippet name is determined by the blob filename (without the `.json` extension). For example, uploading `HelloWorld.json` makes it available at `snippet://HelloWorld`.
-
-Example snippet format:
-
-```json
-{"name": "HelloWorld", "language": "python", "code": "print('Hello, World!')"}
-```
-
-You can add more snippets by creating JSON files and uploading them to the `snippets` blob container.
-
-## Related documentation
-
-- [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)
-- [Azure Functions Python Developer Guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Azure Functions Blob Storage Bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob)
+| Problem | Solution |
+|---------|----------|
+| Connection refused locally | Ensure Azurite is running (`docker run -p 10000:10000 ...`) |
+| API version not supported by Azurite | Add `--skipApiVersionCheck` flag to the Azurite command, or pull the latest image |
+| `AttributeError: 'FunctionApp' object has no attribute 'mcp_resource_trigger'` | Python 3.13 is required. Verify with `python3 --version`. |
+| `azd up` provision succeeded but deploy failed | Transient error — run `azd deploy` again |

--- a/src/FunctionsMcpTool/README.md
+++ b/src/FunctionsMcpTool/README.md
@@ -1,124 +1,158 @@
-# FunctionsMcpTool - MCP Server Sample
+# FunctionsMcpTool — Remote MCP Server on Azure Functions (Python)
 
-This Azure Functions app implements an MCP server that demonstrates various tool patterns, including rich content responses, structured data, batch operations, and Azure Blob Storage integration. It provides comprehensive examples of MCP capabilities on Azure Functions.
+This project is a Python Azure Function app that exposes multiple MCP (Model Context Protocol) tools as a remote MCP server. It includes tools for snippets, QR code generation, structured metadata, batch operations, and more.
+
+> **Note:** MCP resources are in the [FunctionsMcpResources](../FunctionsMcpResources/) project, and prompts are in the [FunctionsMcpPrompts](../FunctionsMcpPrompts/) project.
 
 > [!NOTE]
 > This project uses the **preview extension bundle** (`Microsoft.Azure.Functions.ExtensionBundle.Preview`) configured in `host.json`. The preview bundle is required because some return types (e.g., `CallToolResult`, `ImageContent`) are not yet supported in the standard bundle.
 
-## Features
+## Tools included
 
-This MCP server provides the following tools organized by category:
-
-### Basic Tools
-
-- **hello_mcp**: Simple hello world tool for testing connectivity
-- **get_snippet**: Retrieve a saved code snippet by name from Azure Blob Storage
-- **save_snippet**: Save a code snippet with a name to Azure Blob Storage
-
-### Rich Content Tools
-
-- **generate_qr_code**: Generates a QR code PNG from text and returns it as base64-encoded `ImageContent` (demonstrates single image response)
-
-### Advanced Snippet Tools
-
-- **get_snippet_with_metadata**: Returns snippet content plus structured JSON metadata (demonstrates `CallToolResult` with content blocks and structured data)
-- **batch_save_snippets**: Saves multiple snippets in a single operation (demonstrates batch/array tool inputs)
-- **save_snippet_structured**: Saves a snippet and returns a structured `Snippet` object (demonstrates POCO/dataclass pattern)
+| Tool | Description |
+|------|-------------|
+| `hello_mcp` | Simple hello world tool |
+| `get_snippet` | Retrieves a code snippet from blob storage |
+| `save_snippet` | Saves a code snippet to blob storage |
+| `generate_qr_code` | Generates a QR code image from text |
+| `get_snippet_with_metadata` | Retrieves a snippet with structured metadata |
+| `batch_save_snippets` | Saves multiple snippets at once |
+| `save_snippet_structured` | Saves a snippet and returns a structured dataclass |
 
 ## Prerequisites
 
 - [Python](https://www.python.org/downloads/) version 3.13 or higher
 - [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?pivots=programming-language-python#install-the-azure-functions-core-tools) >= `4.8.0`
-- Azure Storage Emulator (Azurite) for local development
+- [Azure Developer CLI (azd)](https://aka.ms/azd) **1.23.x or above** (for deployment)
+- [Docker](https://www.docker.com/) (for the Azurite storage emulator)
 
-## Local Development
+## Prepare your local environment
 
-### 1. Start Azurite
-
-An Azure Storage Emulator is needed to store snippets locally:
+An Azure Storage Emulator is needed because the snippet tools save and retrieve blobs from storage. Start Azurite:
 
 ```shell
-docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 \
     mcr.microsoft.com/azure-storage/azurite \
     azurite --skipApiVersionCheck --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0
 ```
 
-### 2. Install Dependencies
+> If you use the Azurite VS Code extension instead, run **Azurite: Start** now.
 
-From the `src/FunctionsMcpTool` directory, create and activate a virtual environment, then install dependencies:
+## Run locally
+
+### 1. Install dependencies
+
+From this directory (`src/FunctionsMcpTool`), create and activate a virtual environment, then install dependencies:
 
 ```shell
 python3 -m venv .venv
-
-# macOS/Linux
-source .venv/bin/activate    
-
-# Windows
-.venv\Scripts\activate  
-
+source .venv/bin/activate    # macOS/Linux
+.venv\Scripts\activate       # Windows
 pip install -r requirements.txt
 ```
 
-### 3. Run the Function App
+### 2. Start the Functions host
 
 ```shell
 func start
 ```
 
-## Using the MCP Server
+## Connect to the MCP server
 
-### Connect from VS Code - GitHub Copilot
+### Option A: VS Code with GitHub Copilot
 
-1. Open [.vscode/mcp.json](../../.vscode/mcp.json)
-2. Find the server called `local-mcp-function` and click **Start**. The server uses the endpoint: `http://localhost:7071/runtime/webhooks/mcp`
-3. In Copilot chat agent mode, try these prompts:
-   
-   **Basic Tools:**
-   - "Say Hello"
-   - "Save this snippet as snippet1" (with code selected)
-   - "Retrieve snippet1 and apply to newFile.py"
-   
-   **Rich Content Tools:**
-   - "Generate a QR code for https://example.com"
-   
-   **Advanced Tools:**
-   - "Get snippet1 with metadata"
-   - "Batch save these snippets: [{'name': 'test1', 'content': 'code1'}, {'name': 'test2', 'content': 'code2'}]"
+1. Open **`.vscode/mcp.json`** in the workspace root. Find the server called **`local-mcp-function`** and click **Start** above the name. It points to:
 
-### Connect from MCP Inspector
+   ```
+   http://localhost:7071/runtime/webhooks/mcp
+   ```
 
-1. Install and run MCP Inspector:
+2. In Copilot chat **agent** mode, try prompts like:
+
+   ```
+   Say Hello
+   ```
+
+   ```
+   Save this snippet as snippet1
+   ```
+
+   ```
+   Retrieve snippet1 and apply to NewFile.py
+   ```
+
+3. When prompted to run a tool, consent by clicking **Continue**.
+
+4. Press `Ctrl+C` in the terminal to stop the function host when done.
+
+### Option B: MCP Inspector
+
+1. In a new terminal, install and run MCP Inspector:
+
    ```shell
    npx @modelcontextprotocol/inspector
    ```
-2. Open the URL displayed (e.g., http://0.0.0.0:5173/#resources)
-3. Set transport type to `Streamable HTTP`
-4. Set URL to `http://0.0.0.0:7071/runtime/webhooks/mcp` and **Connect**
-5. **List Tools**, select a tool, and **Run Tool**
 
-## Verify Local Storage
+2. Open the Inspector URL (e.g. `http://0.0.0.0:5173/#resources`).
+3. Set the transport type to **Streamable HTTP**.
+4. Set the URL to `http://0.0.0.0:7071/runtime/webhooks/mcp` and click **Connect**.
+5. Click **List Tools**, select a tool, and **Run Tool**.
 
-After saving snippets, verify they're stored in Azurite:
+## Deploy to Azure
 
-### Using Azure Storage Explorer
-
-1. Open Azure Storage Explorer
-2. Navigate to **Emulator & Attached** → **Storage Accounts** → **(Emulator - Default Ports) (Key)**
-3. Go to **Blob Containers** → **snippets**
-4. View your saved snippet blobs
-
-### Using Azure CLI
+### Step 1: Sign in
 
 ```shell
-# List blobs in the snippets container
-az storage blob list --container-name snippets --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+az login
+azd auth login
 ```
 
-## How It Works
+### Step 2: Create an environment
 
-The function uses Azure Functions' first-class MCP decorators to expose tools:
+```shell
+azd env new <environment-name>
+```
 
-### Basic Tool Example
+This also becomes the resource group name.
+
+### Step 3: Provision and deploy
+
+By default, OAuth-based authentication is enabled using the [built-in MCP auth feature](https://learn.microsoft.com/azure/app-service/configure-authentication-mcp?toc=/azure/azure-functions/toc.json&bc=/azure/azure-functions/breadcrumb/toc.json) with Microsoft Entra as the identity provider.
+
+Configure VS Code as an allowed client application for Microsoft Entra:
+
+```shell
+azd env set PRE_AUTHORIZED_CLIENT_IDS aebc6443-996d-45c2-90f0-388ff96faa56
+```
+
+Optionally enable VNet isolation:
+
+```shell
+azd env set VNET_ENABLED true
+```
+
+Deploy the project. When prompted, pick your subscription and an Azure region.
+
+```shell
+azd up
+```
+
+### Step 4: Connect to the remote MCP server
+
+Open **`.vscode/mcp.json`** and click **Start** above **`remote-mcp-function`**. You'll be prompted for `functionapp-name` — find it in your `azd` command output or the `.azure/<env>/.env` file. Since authentication is enabled, you'll also be prompted to sign in with Microsoft.
+
+> **Tip:** Click **More... → Show Output** above the server name to see request/response details.
+
+### Redeploy and clean up
+
+- **Redeploy:** `azd deploy`
+- **Clean up all resources:** `azd down`
+
+## Examining the code
+
+Each tool is a Python function with an `@app.mcp_tool()` decorator that exposes it as an MCP tool:
+
+### Basic Tool
 
 ```python
 @app.mcp_tool()
@@ -139,14 +173,13 @@ def get_snippet(file: func.InputStream, snippetname: str) -> str:
     return snippet_content
 ```
 
-### Rich Content Response - Single Image
+### Rich Content Response — Single Image
 
 ```python
 @app.mcp_tool()
 @app.mcp_tool_property(arg_name="text", description="The text to encode in the QR code.", required=True)
 def generate_qr_code(text: str) -> ImageContent:
     """Generates a QR code PNG and returns it as a base64-encoded image."""
-    # Generate QR code...
     return ImageContent(
         type="image",
         data=base64.b64encode(png_bytes).decode('utf-8'),
@@ -154,80 +187,11 @@ def generate_qr_code(text: str) -> ImageContent:
     )
 ```
 
-### Structured Content with Metadata
-
-```python
-@app.mcp_tool()
-@app.mcp_tool_property(arg_name="snippetname", description="The name of the snippet.", required=True)
-def get_snippet_with_metadata(snippetname: str) -> Dict[str, Any]:
-    """Returns both content blocks and structured metadata."""
-    metadata = {
-        "name": snippetname,
-        "found": snippet_content is not None,
-        "character_count": len(snippet_content) if snippet_content else 0,
-        "retrieved_at": datetime.now(timezone.utc).isoformat()
-    }
-    
-    return {
-        "content": [
-            {"type": "text", "text": snippet_content or "Not found"},
-            {"type": "text", "text": json.dumps(metadata, indent=2)}
-        ],
-        "structured_content": metadata
-    }
-```
-
-### Batch Operations
-
-```python
-@app.mcp_tool()
-@app.mcp_tool_property(
-    arg_name="snippet_items",
-    description="Array of snippet objects with 'name' and 'content' properties",
-    required=True
-)
-async def batch_save_snippets(snippet_items: List[Dict[str, str]]) -> str:
-    """Saves multiple snippets in a single operation."""
-    # Save each snippet to blob storage...
-    return json.dumps({
-        "message": f"Successfully saved {len(saved_snippets)} snippets",
-        "snippets": saved_snippets
-    })
-```
-
-### Structured Data Class (POCO Pattern)
-
-```python
-@dataclass
-class Snippet:
-    """Snippet model for structured content."""
-    name: str
-    content: Optional[str] = None
-
-@app.mcp_tool()
-@app.mcp_tool_property(arg_name="name", description="The name of the snippet", required=True)
-@app.mcp_tool_property(arg_name="content", description="The code snippet content", required=True)
-def save_snippet_structured(name: str, content: str) -> Snippet:
-    """Returns a structured dataclass instance."""
-    # Save to storage...
-    return Snippet(name=name, content=content)
-```
-
-The MCP decorators automatically:
-- Infer tool properties from function signatures and type hints
-- Handle JSON serialization for rich content types
-- Support batch operations with array/object inputs
-- Expose the functions as MCP tools without manual configuration
-
-## Deployment to Azure
-
-See [Deploy to Azure for Remote MCP](../../README.md#deploy-to-azure-for-remote-mcp) for deployment instructions. 
-
 ## Troubleshooting
 
-| Error | Solution |
-|---|---|
-| `AttributeError: 'FunctionApp' object has no attribute 'mcp_resource_trigger'` | Python 3.13 is required. Verify with `python3 --version`. Install via `brew install python@3.13` (macOS) or from [python.org](https://www.python.org/downloads/). Recreate your virtual environment with Python 3.13 after installing. |
-| Connection refused | Ensure Azurite is running with `--skipApiVersionCheck` flag |
-| API version not supported by Azurite | Add `--skipApiVersionCheck` flag to the Azurite command, or pull the latest Azurite image |
-| Blob not found | Verify the snippet was saved successfully and the name matches exactly |
+| Problem | Solution |
+|---------|----------|
+| Connection refused locally | Ensure Azurite is running (`docker run -p 10000:10000 ...`) |
+| API version not supported by Azurite | Add `--skipApiVersionCheck` flag to the Azurite command, or pull the latest image |
+| `AttributeError: 'FunctionApp' object has no attribute 'mcp_resource_trigger'` | Python 3.13 is required. Verify with `python3 --version`. |
+| `azd up` provision succeeded but deploy failed | Transient error — run `azd deploy` again |

--- a/src/McpWeatherApp/README.md
+++ b/src/McpWeatherApp/README.md
@@ -144,9 +144,55 @@ cd app
 npm run build
 ```
 
-## Deployment to Azure
+## Deploy to Azure
 
-See [Deploy to Azure for Remote MCP](../../README.md#deploy-to-azure-for-remote-mcp) for deployment instructions. The UI will be automatically bundled and deployed with the function app. 
+### Step 1: Sign in
+
+```shell
+az login
+azd auth login
+```
+
+### Step 2: Create an environment
+
+```shell
+azd env new <environment-name>
+```
+
+This also becomes the resource group name.
+
+### Step 3: Provision and deploy
+
+By default, OAuth-based authentication is enabled using the [built-in MCP auth feature](https://learn.microsoft.com/azure/app-service/configure-authentication-mcp?toc=/azure/azure-functions/toc.json&bc=/azure/azure-functions/breadcrumb/toc.json) with Microsoft Entra as the identity provider.
+
+Configure VS Code as an allowed client application for Microsoft Entra:
+
+```shell
+azd env set PRE_AUTHORIZED_CLIENT_IDS aebc6443-996d-45c2-90f0-388ff96faa56
+```
+
+Optionally enable VNet isolation:
+
+```shell
+azd env set VNET_ENABLED true
+```
+
+Deploy the project. When prompted, pick your subscription and an Azure region.
+
+```shell
+azd up
+```
+
+The UI will be automatically bundled and deployed with the function app.
+
+### Step 4: Connect to the remote MCP server
+
+Open **`.vscode/mcp.json`** and click **Start** above **`remote-mcp-function`**. You'll be prompted for `functionapp-name` — find it in your `azd` command output or the `.azure/<env>/.env` file. Since authentication is enabled, you'll also be prompted to sign in with Microsoft.
+
+### Redeploy and clean up
+
+- **Redeploy:** `azd deploy`
+- **Clean up all resources:** `azd down`
 
 ## Weather Service
 


### PR DESCRIPTION
- Simplify root README: intro, prerequisites, project table, next steps
- Move deployment instructions into each sub-project README
- Each project now has self-contained: prerequisites, local dev, deploy, troubleshooting
- Add deploy sections to FunctionsMcpPrompts and McpWeatherApp
- Remove redundant sections from root (architecture, helpful commands, etc.)
